### PR TITLE
Fixing mis-positioning of mobile overflow menu

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-overflow-menu",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "fs-overflow-menu.html",
   "dependencies": {
     "polymer": "Polymer/polymer#1 - 2",

--- a/fs-overflow-menu.html
+++ b/fs-overflow-menu.html
@@ -255,7 +255,7 @@ Example:
       }
 
       /* Set the position of the menu. */
-      var menuLeftPosition = this._calculateMenuLeftPosition();
+      var menuLeftPosition = this._isMobile ? 10 : this._calculateMenuLeftPosition();
       this.style.left = menuLeftPosition + 'px';
 
       /* Needed for Safari. */
@@ -500,6 +500,7 @@ Example:
         params.isMobile = false;
       }
       this._isMobile = params.isMobile;
+      if (params.isMobile) this.dropPosition = "LEFT"
 
       this.isContextMenu = false;
       this._fireHideMenuEvent();

--- a/fs-overflow-menu.html
+++ b/fs-overflow-menu.html
@@ -500,7 +500,7 @@ Example:
         params.isMobile = false;
       }
       this._isMobile = params.isMobile;
-      if (params.isMobile) this.dropPosition = "LEFT"
+      if (params.isMobile) this.dropPosition = "LEFT";
 
       this.isContextMenu = false;
       this._fireHideMenuEvent();


### PR DESCRIPTION
I found that on mobile the "dropPosition" was set to "RIGHT" which seemed to through off the left positioning. 

On mobile setting the `dropPosition` to LEFT and setting the left menu position to 10 allows the menu to be visible 

Fixes JIRA [PS-4082](https://fhjira.churchofjesuschrist.org/browse/PS-4082)